### PR TITLE
fix(a11y): add a `role="navigation"` attribute to the `nav` element

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <div ref="sideNav" class="bm-menu">
-            <nav class="bm-item-list">
+            <nav class="bm-item-list" role="navigation">
                 <slot></slot>
             </nav>
             <span class="bm-cross-button cross-style" @click="closeMenu" :class="{ hidden: !crossIcon }">


### PR DESCRIPTION
To improve accessibility, using the `role` attribute is important. In this case, adding the `role="navigation"` on the `nav` element helps screen readers to understand the website page layout.